### PR TITLE
feat: add balance check history and improve consumption calculation

### DIFF
--- a/canfund-rs/src/manager/history.rs
+++ b/canfund-rs/src/manager/history.rs
@@ -1,0 +1,47 @@
+use std::collections::VecDeque;
+
+#[derive(Clone)]
+pub struct ConsumptionHistory {
+    /// The history of the consumed cycles.
+    samples: VecDeque<u64>,
+    /// The sum of the consumed cycles.
+    sum: u64,
+    /// The number of history elements to keep.
+    window_size: usize,
+}
+
+impl ConsumptionHistory {
+    /// Constructs a new ConsumptionHistory with the specified window size.
+    pub fn new(window_size: usize) -> Self {
+        Self {
+            samples: VecDeque::with_capacity(window_size),
+            sum: 0,
+            window_size,
+        }
+    }
+
+    /// Adds a new sample to the history.
+    pub fn add_sample(&mut self, consumption: u64) {
+        if self.window_size == 0 {
+            return;
+        }
+
+        if self.samples.len() == self.window_size {
+            let oldest_sample = self.samples.pop_front().unwrap();
+            self.sum -= oldest_sample;
+        }
+
+        self.samples.push_back(consumption);
+
+        self.sum += consumption;
+    }
+
+    /// Returns the average of the samples in the history.
+    pub fn average(&self) -> u64 {
+        if self.samples.is_empty() {
+            return 0;
+        }
+
+        self.sum / self.samples.len() as u64
+    }
+}

--- a/canfund-rs/src/manager/record.rs
+++ b/canfund-rs/src/manager/record.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::operations::fetch::FetchCyclesBalance;
 
-use super::options::FundStrategy;
+use super::{history::ConsumptionHistory, options::FundStrategy};
 
 #[derive(Clone)]
 pub struct CanisterRecord {
@@ -10,6 +10,8 @@ pub struct CanisterRecord {
     cycles: Option<CyclesBalance>,
     /// The canister cycles balance record when it was last funded.
     previous_cycles: Option<CyclesBalance>,
+    /// The cycles consumption history of the canister.
+    consumtion_history: ConsumptionHistory,
     /// The cumulative total of cycles deposited to the canister.
     deposited_cycles: Option<CyclesBalance>,
     /// The method to fetch the canister cycles balance.
@@ -22,9 +24,11 @@ impl CanisterRecord {
     pub fn new(
         cycles_fetcher: Arc<dyn FetchCyclesBalance>,
         strategy: Option<FundStrategy>,
+        history_window_size: usize,
     ) -> Self {
         Self {
             cycles: None,
+            consumtion_history: ConsumptionHistory::new(history_window_size),
             previous_cycles: None,
             deposited_cycles: None,
             cycles_fetcher,
@@ -35,6 +39,10 @@ impl CanisterRecord {
     pub fn set_cycles(&mut self, cycles: CyclesBalance) {
         if let Some(previous_cycles) = self.cycles.as_ref() {
             self.previous_cycles = Some(previous_cycles.clone());
+            self.consumtion_history.add_sample(
+                previous_cycles.amount.saturating_sub(cycles.amount) as u64 * 1_000_000_000
+                    / cycles.timestamp.saturating_sub(previous_cycles.timestamp),
+            );
         }
 
         self.cycles = Some(cycles);
@@ -48,13 +56,21 @@ impl CanisterRecord {
         &self.previous_cycles
     }
 
-    pub fn add_deposited_cycles(&mut self, cycles: CyclesBalance) {
-        if let Some(deposited_cycles) = self.deposited_cycles.as_mut() {
-            deposited_cycles.amount = deposited_cycles.amount.saturating_add(cycles.amount);
-            deposited_cycles.timestamp = cycles.timestamp;
+    pub fn add_deposited_cycles(&mut self, deposited_cycles: CyclesBalance) {
+        if let Some(total_deposited_cycles) = self.deposited_cycles.as_mut() {
+            total_deposited_cycles.amount = total_deposited_cycles
+                .amount
+                .saturating_add(deposited_cycles.amount);
+            total_deposited_cycles.timestamp = deposited_cycles.timestamp;
         } else {
-            self.deposited_cycles = Some(cycles);
+            self.deposited_cycles = Some(deposited_cycles.clone());
         }
+
+        // Update the cycles balance to reflect the deposited amount.
+        // This allows for the history to be accuratly calculated.
+        self.cycles = self.cycles.as_ref().map(|cycles| {
+            CyclesBalance::new(cycles.amount + deposited_cycles.amount, cycles.timestamp)
+        });
     }
 
     pub fn get_deposited_cycles(&self) -> &Option<CyclesBalance> {
@@ -67,6 +83,11 @@ impl CanisterRecord {
 
     pub fn get_strategy(&self) -> &Option<FundStrategy> {
         &self.strategy
+    }
+
+    /// Returns the average consumption of the canister in cycles per second.
+    pub fn get_average_consumption(&self) -> u64 {
+        self.consumtion_history.average()
     }
 }
 
@@ -95,15 +116,15 @@ mod tests {
     #[test]
     fn test_canister_record() {
         let cycles_fetcher = Arc::new(FetchOwnCyclesBalance);
-        let mut canister_record = CanisterRecord::new(cycles_fetcher, None);
+        let mut canister_record = CanisterRecord::new(cycles_fetcher, None, 0);
 
-        let cycles = CyclesBalance::new(100, 0);
+        let cycles = CyclesBalance::new(100, 100);
         canister_record.set_cycles(cycles.clone());
         assert_eq!(canister_record.get_cycles(), &Some(cycles));
         assert_eq!(canister_record.get_previous_cycles(), &None);
 
         let previous_cycles = canister_record.get_cycles().as_ref().unwrap().clone();
-        canister_record.set_cycles(CyclesBalance::new(200, 0));
+        canister_record.set_cycles(CyclesBalance::new(200, 200));
         assert_eq!(
             canister_record.get_previous_cycles(),
             &Some(previous_cycles)
@@ -121,5 +142,28 @@ mod tests {
             canister_record.get_deposited_cycles(),
             &Some(CyclesBalance::new(100, deposited_cycles.timestamp))
         );
+
+        assert_eq!(canister_record.get_average_consumption(), 0);
+    }
+
+    #[test]
+    fn test_canister_consumption() {
+        let cycles_fetcher = Arc::new(FetchOwnCyclesBalance);
+        let mut canister_record = CanisterRecord::new(cycles_fetcher, None, 5);
+
+        canister_record.set_cycles(CyclesBalance::new(300_000, 1_000_000_000));
+        canister_record.set_cycles(CyclesBalance::new(200_000, 2_000_000_000));
+        canister_record.set_cycles(CyclesBalance::new(250_000, 3_000_000_000)); // reservations returned
+
+        canister_record.add_deposited_cycles(CyclesBalance::new(500_000, 3_000_000_100));
+
+        assert_eq!(canister_record.get_average_consumption(), 50_000);
+
+        canister_record.set_cycles(CyclesBalance::new(600_000, 4_000_000_000));
+        canister_record.set_cycles(CyclesBalance::new(350_000, 5_000_000_000));
+        canister_record.set_cycles(CyclesBalance::new(250_000, 6_000_000_000));
+        canister_record.set_cycles(CyclesBalance::new(200_000, 7_000_000_000));
+
+        assert_eq!(canister_record.get_average_consumption(), 110_000);
     }
 }

--- a/canfund-rs/src/utils.rs
+++ b/canfund-rs/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::{errors::Error, manager::record::CyclesBalance};
+use crate::errors::Error;
 
 /// Converts the cycles from `candid::Nat` to `u128`.
 pub fn cycles_nat_to_u128(cycles: candid::Nat) -> Result<u128, Error> {
@@ -20,30 +20,6 @@ pub fn cycles_str_to_u128(cycles: &str) -> Result<u128, Error> {
             cycles: cycles.to_string(),
         }),
     }
-}
-
-/// Calculates the estimated cycles per second based on the current and previous cycles balance.
-pub fn calc_estimated_cycles_per_sec(
-    current_cycles: &CyclesBalance,
-    previous_cycles: &CyclesBalance,
-) -> u128 {
-    // The current cycles balance should be a measurement after the previous cycles balance.
-    if current_cycles.timestamp <= previous_cycles.timestamp {
-        return 0;
-    }
-
-    let consumed_cycles = previous_cycles.amount.saturating_sub(current_cycles.amount);
-
-    // time_spent is never 0 because the timestamp is always increasing.
-    let time_spent_in_ns = current_cycles.timestamp - previous_cycles.timestamp;
-    let time_spent_in_milis = time_spent_in_ns / 1_000_000;
-    let time_spent_in_secs = time_spent_in_milis / 1_000;
-
-    if time_spent_in_secs == 0 {
-        return 0;
-    }
-
-    consumed_cycles / time_spent_in_secs as u128
 }
 
 #[cfg(test)]
@@ -80,107 +56,5 @@ mod tests {
                 cycles: "".to_string(),
             }
         );
-    }
-
-    #[test]
-    fn test_calc_estimated_cycles_per_sec() {
-        let previous_cycles = CyclesBalance {
-            amount: 75_000_000_000,
-            timestamp: 10 * 1000 * 1_000_000,
-        };
-        let current_cycles = CyclesBalance {
-            amount: 50_000_000_000,
-            timestamp: 15 * 1000 * 1_000_000,
-        };
-
-        let estimated_cycles_per_sec =
-            calc_estimated_cycles_per_sec(&current_cycles, &previous_cycles);
-
-        assert_eq!(estimated_cycles_per_sec, 5_000_000_000);
-    }
-
-    #[test]
-    fn test_calc_estimated_cycles_per_sec_zero_time_spent() {
-        let previous_cycles = CyclesBalance {
-            amount: 50_000_000_000,
-            timestamp: 10 * 1000 * 1_000_000,
-        };
-        let current_cycles = CyclesBalance {
-            amount: 50_000_000_000,
-            timestamp: 10 * 1000 * 1_000_000,
-        };
-
-        let estimated_cycles_per_sec =
-            calc_estimated_cycles_per_sec(&current_cycles, &previous_cycles);
-
-        assert_eq!(estimated_cycles_per_sec, 0);
-    }
-
-    #[test]
-    fn test_calc_estimated_cycles_per_sec_negative() {
-        let previous_cycles = CyclesBalance {
-            amount: 50_000_000_000,
-            timestamp: 15 * 1000 * 1_000_000,
-        };
-        let current_cycles = CyclesBalance {
-            amount: 75_000_000_000,
-            timestamp: 10 * 1000 * 1_000_000,
-        };
-
-        let estimated_cycles_per_sec =
-            calc_estimated_cycles_per_sec(&current_cycles, &previous_cycles);
-
-        assert_eq!(estimated_cycles_per_sec, 0);
-    }
-
-    #[test]
-    fn test_calc_estimated_cycles_per_sec_zero_consumed_cycles() {
-        let previous_cycles = CyclesBalance {
-            amount: 50_000_000_000,
-            timestamp: 10 * 1000 * 1_000_000,
-        };
-        let current_cycles = CyclesBalance {
-            amount: 50_000_000_000,
-            timestamp: 15 * 1000 * 1_000_000,
-        };
-
-        let estimated_cycles_per_sec =
-            calc_estimated_cycles_per_sec(&current_cycles, &previous_cycles);
-
-        assert_eq!(estimated_cycles_per_sec, 0);
-    }
-
-    #[test]
-    fn test_calc_estimated_cycles_per_sec_zero_previous_cycles() {
-        let previous_cycles = CyclesBalance {
-            amount: 50_000_000_000,
-            timestamp: 0,
-        };
-        let current_cycles = CyclesBalance {
-            amount: 0,
-            timestamp: 10 * 1000 * 1_000_000,
-        };
-
-        let estimated_cycles_per_sec =
-            calc_estimated_cycles_per_sec(&current_cycles, &previous_cycles);
-
-        assert_eq!(estimated_cycles_per_sec, 5_000_000_000);
-    }
-
-    #[test]
-    fn test_calc_estimated_cycles_per_sec_current_has_more_cycles() {
-        let previous_cycles = CyclesBalance {
-            amount: 75_000_000_000,
-            timestamp: 10 * 1000 * 1_000_000,
-        };
-        let current_cycles = CyclesBalance {
-            amount: 100_000_000_000,
-            timestamp: 15 * 1000 * 1_000_000,
-        };
-
-        let estimated_cycles_per_sec =
-            calc_estimated_cycles_per_sec(&current_cycles, &previous_cycles);
-
-        assert_eq!(estimated_cycles_per_sec, 0);
     }
 }

--- a/tests/integration/build.rs
+++ b/tests/integration/build.rs
@@ -76,7 +76,7 @@ lazy_static! {
         let mut packages = Vec::new();
         let examples_path = WORKSPACE_ROOT.join("examples");
 
-        for entry in fs::read_dir(&examples_path).expect("Failed to read serializers directory") {
+        for entry in fs::read_dir(examples_path).expect("Failed to read serializers directory") {
             let entry = entry.expect("Failed to read entry");
             let path = entry.path();
 
@@ -230,8 +230,7 @@ pub fn download_pocket_ic() {
 
     let uncompressed_path = output_path.with_extension("");
 
-    fs::rename(&uncompressed_path, OUT_DIR.join(POCKET_IC_BIN_NAME))
-        .expect("Failed to rename file");
+    fs::rename(uncompressed_path, OUT_DIR.join(POCKET_IC_BIN_NAME)).expect("Failed to rename file");
     fs::set_permissions(
         OUT_DIR.join(POCKET_IC_BIN_NAME),
         fs::Permissions::from_mode(0o755),


### PR DESCRIPTION
This PR enhances the logic for calculating average consumption per second by adjusting it to consider a time window equal to the minimal runtime threshold for each canister record.

While fluctuations in the number of reservations between status checks can still lead to inaccuracies, using a longer time window provides a more accurate estimate of consumption over time.