### PR TITLE
feat(fetch): consider freezing threshold in mngmt canister balance fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Each canister that you want to fund using `canfund` must be registered. During r
    ```rust
    let fetcher = FetchCyclesBalanceFromCanisterStatus;
    ```
+   This is currently the only method that subtracts the _freezing_threshold_ of the canister. The runtime and threshold funding strategies ([below](#funding-strategies)) are thus calculated from the point when a canister gets frozen.
 
 2. **FetchOwnCyclesBalance**: Fetches the cycle balance using the `ic_cdk::api::canister_balance` method. This method is only suitable for checking the balance of the current canister.
 

--- a/canfund-rs/src/manager/mod.rs
+++ b/canfund-rs/src/manager/mod.rs
@@ -243,7 +243,6 @@ impl FundManager {
                         ),
                         maybe_funding_canister_record
                             .as_ref()
-                            .as_ref()
                             .map(|record| record.get_average_consumption() as u128)
                             .unwrap_or(0),
                         &maybe_funding_canister_record

--- a/canfund-rs/src/manager/mod.rs
+++ b/canfund-rs/src/manager/mod.rs
@@ -243,7 +243,8 @@ impl FundManager {
                         ),
                         maybe_funding_canister_record
                             .as_ref()
-                            .as_ref().map(|record| record.get_average_consumption() as u128)
+                            .as_ref()
+                            .map(|record| record.get_average_consumption() as u128)
                             .unwrap_or(0),
                         &maybe_funding_canister_record
                             .as_ref()

--- a/canfund-rs/src/operations/fetch.rs
+++ b/canfund-rs/src/operations/fetch.rs
@@ -195,7 +195,12 @@ fn extract_cycles_from_http_response_body(body: &str, metric_name: &str) -> Resu
 }
 
 fn calc_freezing_balance(freezing_threshold: u128, idle_cycles_burned_per_day: u128) -> u128 {
-    (idle_cycles_burned_per_day as f64 * freezing_threshold as f64 / 86_400.0) as u128
+    // u128 should safely handle the multiplication without overflow and provides enough precision for the division result.
+    // e.g. 
+    //  freezing threshold for 100 years ~ 3 * 10^9
+    //  idle cycles burned per day with 1 TB of storage  = 844 * 10^9
+    //  u128 limit ~ 3 * 10^38
+    idle_cycles_burned_per_day * freezing_threshold / 86_400
 }
 
 #[cfg(test)]

--- a/canfund-rs/src/operations/fetch.rs
+++ b/canfund-rs/src/operations/fetch.rs
@@ -278,6 +278,7 @@ mod tests {
     #[test]
     fn test_calc_needed_cycles() {
         assert_eq!(calc_freezing_balance(24 * 60 * 60, 1), 1);
+        assert_eq!(calc_freezing_balance(12 * 60 * 60, 100), 50);
         assert_eq!(calc_freezing_balance(10 * 24 * 60 * 60, 50_000), 500_000);
         assert_eq!(calc_freezing_balance(30 * 24 * 60 * 60, 123456), 3_703_680);
     }

--- a/canfund-rs/src/operations/fetch.rs
+++ b/canfund-rs/src/operations/fetch.rs
@@ -195,8 +195,7 @@ fn extract_cycles_from_http_response_body(body: &str, metric_name: &str) -> Resu
 }
 
 fn calc_freezing_balance(freezing_threshold: u128, idle_cycles_burned_per_day: u128) -> u128 {
-    let idle_cycles_burned_per_second = idle_cycles_burned_per_day / 86_400;
-    freezing_threshold * idle_cycles_burned_per_second
+    (idle_cycles_burned_per_day as f64 * freezing_threshold as f64 / 86_400.0) as u128
 }
 
 #[cfg(test)]
@@ -274,5 +273,12 @@ mod tests {
                 cycles: "invalid".to_string()
             }
         );
+    }
+
+    #[test]
+    fn test_calc_needed_cycles() {
+        assert_eq!(calc_freezing_balance(24 * 60 * 60, 1), 1);
+        assert_eq!(calc_freezing_balance(10 * 24 * 60 * 60, 50_000), 500_000);
+        assert_eq!(calc_freezing_balance(30 * 24 * 60 * 60, 123456), 3_703_680);
     }
 }


### PR DESCRIPTION
This PR updates the management canister balance fetching strategy to subtract the freezing threshold from the returned value. This allows funding strategies to only count with runtime and threshold to the actual freezing time of a canister.