### PR TITLE
refactor: remove outdated FetchOwnCyclesBalance fetching method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To use `canfund`, configure it with rules for managing cycles for your canisters
 
 ### Canister Registration
 
-Each canister that you want to fund using `canfund` must be registered. During registration, you must specify the method by which the canister's cycle balance will be fetched. `canfund` supports three different balance-fetching methods:
+Each canister that you want to fund using `canfund` must be registered. During registration, you must specify the method by which the canister's cycle balance will be fetched. `canfund` supports two different balance-fetching methods:
 
 1. **FetchCyclesBalanceFromCanisterStatus**: Fetches the canister's cycle balance by calling the `canister_status` method on the management canister. This method is only suitable if the caller has permission to invoke `canister_status`, which is typically restricted to the controllers of the target canister.
 
@@ -77,11 +77,6 @@ Each canister that you want to fund using `canfund` must be registered. During r
    ```
    This is currently the only method that subtracts the _freezing_threshold_ of the canister. The runtime and threshold funding strategies ([below](#funding-strategies)) are thus calculated from the point when a canister gets frozen.
 
-2. **FetchOwnCyclesBalance**: Fetches the cycle balance using the `ic_cdk::api::canister_balance` method. This method is only suitable for checking the balance of the current canister.
-
-   ```rust
-   let fetcher = FetchCyclesBalanceFromCanisterStatus
-   ```
 
 3. **FetchCyclesBalanceFromPrometheusMetrics**: Fetches the cycle balance by leveraging Prometheus metrics exposed by the canister through an HTTP endpoint.
 
@@ -214,7 +209,7 @@ fn initialize() {
         ),
     );
 
-    // Funding canister is automatically registered with FetchOwnCyclesBalance strategy
+    // Funding canister is automatically registered
 
     fund_manager.start();
 }

--- a/canfund-rs/src/manager/mod.rs
+++ b/canfund-rs/src/manager/mod.rs
@@ -6,7 +6,7 @@ use self::{
     record::{CanisterRecord, CyclesBalance},
 };
 use crate::operations::fetch::{
-    FetchCyclesBalance, FetchCyclesBalanceFromCanisterStatus, FetchOwnCyclesBalance,
+    FetchCyclesBalance, FetchCyclesBalanceFromCanisterStatus,
 };
 use ic_cdk::{
     api::{
@@ -39,7 +39,7 @@ pub struct FundManagerCore {
 }
 
 /// RegisterOpts holds the options for registering a canister to be monitored by the fund manager.
-/// By default it uses the `FetchCyclesBalanceFromCanisterStatus` to fetch the cycles balance.
+/// By default, it uses the `FetchCyclesBalanceFromCanisterStatus` to fetch the cycles balance.
 /// The fund strategy is set to `None` by default, meaning that the global strategy will be applied.
 pub struct RegisterOpts {
     pub cycles_fetcher: Arc<dyn FetchCyclesBalance>,
@@ -96,7 +96,7 @@ impl FundManager {
 
         manager.register(
             id(),
-            RegisterOpts::new().with_cycles_fetcher(Arc::new(FetchOwnCyclesBalance {})),
+            RegisterOpts::new(),
         );
 
         manager

--- a/canfund-rs/src/manager/record.rs
+++ b/canfund-rs/src/manager/record.rs
@@ -110,13 +110,12 @@ impl CyclesBalance {
 
 #[cfg(test)]
 mod tests {
-    use crate::operations::fetch::FetchOwnCyclesBalance;
-
+    use crate::operations::fetch::FetchCyclesBalanceFromCanisterStatus;
     use super::*;
 
     #[test]
     fn test_canister_record() {
-        let cycles_fetcher = Arc::new(FetchOwnCyclesBalance);
+        let cycles_fetcher = Arc::new(FetchCyclesBalanceFromCanisterStatus);
         let mut canister_record = CanisterRecord::new(cycles_fetcher, None, 0);
 
         let cycles = CyclesBalance::new(100, 100);
@@ -149,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_canister_consumption() {
-        let cycles_fetcher = Arc::new(FetchOwnCyclesBalance);
+        let cycles_fetcher = Arc::new(FetchCyclesBalanceFromCanisterStatus);
         let mut canister_record = CanisterRecord::new(cycles_fetcher, None, 5);
 
         canister_record.set_cycles(CyclesBalance::new(300_000, 1_000_000_000));

--- a/canfund-rs/src/operations/fetch.rs
+++ b/canfund-rs/src/operations/fetch.rs
@@ -66,18 +66,6 @@ impl FetchCyclesBalance for FetchCyclesBalanceFromCanisterStatus {
     }
 }
 
-/// Fetches the canister cycles balance using the `ic_cdk::api::canister_balance` method.
-/// This fetcher is only suitable for the current canister.
-#[derive(Clone)]
-pub struct FetchOwnCyclesBalance;
-
-#[async_trait::async_trait]
-impl FetchCyclesBalance for FetchOwnCyclesBalance {
-    async fn fetch_cycles_balance(&self, _canister_id: CanisterId) -> Result<u128, Error> {
-        Ok(ic_cdk::api::canister_balance128())
-    }
-}
-
 /// Fetches the canister cycles balance by leveraging prometheus metrics
 /// exposed by the canister through an HTTP endpoint.
 #[derive(Clone)]

--- a/examples/advanced_funding/src/lib.rs
+++ b/examples/advanced_funding/src/lib.rs
@@ -81,10 +81,9 @@ pub fn start_canister_cycles_monitoring(config: FundingConfig) {
                     .with_cycles_fetcher(Arc::new(FetchCyclesBalanceFromCanisterStatus)),
             );
         }
-
-        // By default, the fund manager registers its canister with the FetchOwnCyclesBalance operation
-        // We are able to override it with FetchCyclesBalanceFromCanisterStatus because even canisters that
-        // are not their own controller can call the canister_status endpoint
+        
+        // The funding canister itself is also registered for monitoring by default. We can override
+        // the strategy by re-registering it.
         fund_manager.unregister(id());
         fund_manager.register(
             id(),


### PR DESCRIPTION
This method is not relevant anymore and does not provide additional important data, such as freezing_threshold.