### PR TITLE
refactor(manager)!: remove implicit funding canister registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "canfund"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "candid",

--- a/README.md
+++ b/README.md
@@ -223,7 +223,11 @@ fn initialize() {
         ),
     );
 
-    // Funding canister is automatically registered
+    // Note: the funding canister is NOT automatically registered
+    fund_manager.register(
+        id(),
+        RegisterOpts::new(),
+    );
 
     fund_manager.start();
 }

--- a/canfund-rs/src/manager/mod.rs
+++ b/canfund-rs/src/manager/mod.rs
@@ -87,14 +87,10 @@ impl Default for FundManager {
 impl FundManager {
     /// Creates a new fund manager with the specified options.
     pub fn new() -> Self {
-        let mut manager = FundManager {
+        FundManager {
             inner: FundManagerCore::new(),
             tracker: None,
-        };
-
-        manager.register(id(), RegisterOpts::new());
-
-        manager
+        }
     }
 
     /// Configures the fund manager with the specified options.
@@ -185,6 +181,7 @@ impl FundManager {
     }
 
     /// Executes the scheduled monitoring of the canisters and fund them if needed.
+    #[allow(clippy::too_many_lines)]
     async fn execute_scheduled_monitoring(manager: Rc<RefCell<FundManagerCore>>) {
         // Lock the process execution to prevent concurrent executions, it is dropped automatically
         // when it goes out of scope.
@@ -226,7 +223,7 @@ impl FundManager {
                     // Get the current balance.
                     let funding_canister_balance = ic_cdk::api::canister_balance128();
 
-                    // Get the record of the funding canister, if it exists, to access the previsous cycles balance to calculate estimated runtime left.
+                    // Get the record of the funding canister, if it exists, to access the previous cycles balance to calculate estimated runtime left.
                     let maybe_funding_canister_record =
                         manager.borrow().canisters.get(&id()).cloned();
 
@@ -238,8 +235,7 @@ impl FundManager {
                         ),
                         maybe_funding_canister_record
                             .as_ref()
-                            .map(|record| record.get_average_consumption() as u128)
-                            .unwrap_or(0),
+                            .map_or(0, |record| record.get_average_consumption() as u128),
                         &maybe_funding_canister_record
                             .as_ref()
                             .and_then(|record| record.get_strategy().clone())

--- a/examples/advanced_funding/Cargo.toml
+++ b/examples/advanced_funding/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 candid = { workspace = true }
-canfund = { path = "../../canfund-rs", version = "0.2.0" }
+canfund = { path = "../../canfund-rs" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-ledger-types = { workspace = true }

--- a/examples/advanced_funding/src/lib.rs
+++ b/examples/advanced_funding/src/lib.rs
@@ -81,9 +81,7 @@ pub fn start_canister_cycles_monitoring(config: FundingConfig) {
             );
         }
 
-        // The funding canister itself is also registered for monitoring by default. We can override
-        // the strategy by re-registering it.
-        fund_manager.unregister(id());
+        // The funding canister itself can also be monitored.
         fund_manager.register(
             id(),
             RegisterOpts::new()

--- a/examples/simple_funding/Cargo.toml
+++ b/examples/simple_funding/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 candid = { workspace = true }
-canfund = { path = "../../canfund-rs", version = "0.2.0" }
+canfund = { path = "../../canfund-rs" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-ledger-types = { workspace = true }


### PR DESCRIPTION
The original implicit registration caused inflexibility in the configuration

BREAKING CHANGE: The funding canister must be registered explicitly with this update