### PR TITLE
refactor!: remove self top-up configuration for funding canister

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ let obtain_cycles_config = ObtainCyclesOptions {
         )),
         from_subaccount: Subaccount::from(DEFAULT_SUBACCOUNT),
     }),
-    top_up_self: true,
 };
 
 funding_options.with_obtain_cycles_options(Some(obtain_cycles_config));

--- a/canfund-rs/src/manager/mod.rs
+++ b/canfund-rs/src/manager/mod.rs
@@ -253,11 +253,6 @@ impl FundManager {
                         manager.borrow().options().obtain_cycles_options().clone();
 
                     if let Some(obtain_cycles_options) = maybe_obtain_cycles {
-                        if canister_id == id() && !obtain_cycles_options.top_up_self {
-                            // Obtaining cycles solely for topping up the funding canister is disabled.
-                            continue;
-                        }
-
                         ic_cdk::println!(
                             "Topping up {} with {} cycles",
                             canister_id,

--- a/canfund-rs/src/manager/options.rs
+++ b/canfund-rs/src/manager/options.rs
@@ -173,8 +173,6 @@ impl Default for FundStrategy {
 pub struct ObtainCyclesOptions {
     /// How to obtain cycles when the funding canister balance gets low.
     pub obtain_cycles: Arc<dyn ObtainCycles>,
-    /// If canfund should use obtain_cycles to top up the canister balance canfund is running on.
-    pub top_up_self: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/examples/advanced_funding/src/lib.rs
+++ b/examples/advanced_funding/src/lib.rs
@@ -107,7 +107,6 @@ pub fn get_obtain_cycles_config() -> Option<ObtainCyclesOptions> {
             )),
             from_subaccount: DEFAULT_SUBACCOUNT,
         }),
-        top_up_self: true,
     })
 }
 


### PR DESCRIPTION
The funding canister will always be topped up if cycles are needed

BREAKING CHANGE: There is no observed use-case to disable minting for topping up the funding canister
