### PR TITLE
docs: include README in canfund crate

### DIFF
--- a/canfund-rs/src/lib.rs
+++ b/canfund-rs/src/lib.rs
@@ -1,11 +1,4 @@
-//! # Canfund Library
-//!
-//! `canfund` is a library that provides a set of features for managing cycles of a canister.
-//!
-//! Those features include:
-//!
-//! - Monitoring of canister cycles.
-//! - Adding cycles to a canister.
+#![doc = include_str!("../../README.md")]
 
 pub mod api;
 pub mod errors;


### PR DESCRIPTION
 To resolve #25 and with this PR, I suggest to include the README in the `canfund` crate.