### PR TITLE
fix: overflow when computing cycles consumption

### DIFF
--- a/canfund-rs/src/manager/record.rs
+++ b/canfund-rs/src/manager/record.rs
@@ -51,8 +51,8 @@ impl CanisterRecord {
             self.previous_cycles = Some(previous_cycles.clone());
             // Timestamp difference is in nanoseconds, so we need to multiply by 1_000_000_000 to get cycles per second.
             self.consumption_history.add_sample(
-                previous_cycles.amount.saturating_sub(cycles.amount) as u64 * 1_000_000_000
-                    / cycles.timestamp.saturating_sub(previous_cycles.timestamp),
+                (previous_cycles.amount.saturating_sub(cycles.amount) * 1_000_000_000
+                    / cycles.timestamp.saturating_sub(previous_cycles.timestamp) as u128) as u64,
             );
         }
 

--- a/canfund-rs/src/manager/record.rs
+++ b/canfund-rs/src/manager/record.rs
@@ -52,7 +52,8 @@ impl CanisterRecord {
             // Timestamp difference is in nanoseconds, so we need to multiply by 1_000_000_000 to get cycles per second.
             self.consumption_history.add_sample(
                 (previous_cycles.amount.saturating_sub(cycles.amount) * 1_000_000_000
-                    / cycles.timestamp.saturating_sub(previous_cycles.timestamp) as u128) as u64,
+                    / cycles.timestamp.saturating_sub(previous_cycles.timestamp) as u128)
+                    as u64,
             );
         }
 


### PR DESCRIPTION
This PR fixes overflow in the current computation of cycles consumption when the cycles difference is at least `2**64 / 1e9 ~ 18e9` cycles.